### PR TITLE
Fix: Segment intersection

### DIFF
--- a/include/convex.h
+++ b/include/convex.h
@@ -42,7 +42,7 @@ namespace ayw
 		float2 ab = b - a, cd = d - c, ac = c - a;
 		float num = cross(ab, ac);
 		float denom = cross(cd, ab);
-		if (denom == 0) return float2(-BIG_FLOAT, -BIG_FLOAT);
+		if (std::abs(denom) < EPS_FLOAT) return float2(-BIG_FLOAT, -BIG_FLOAT);
 		float t = num / denom;
 		float s = 0;
 		if (std::abs(ab.x) > std::abs(ab.y)) s = (ac.x + cd.x * t) / ab.x;


### PR DESCRIPTION
## Description

This pull request resolves a bug in the function that calculates the intersection of two line segments. The previous implementation failed to correctly handle certain edge cases, leading to inaccurate results.

## Test case

To demonstrate the correction, here is a minimal reproducible example.

```
#include "include/convex.h"
#include <vector>
#include <iostream>

int main(int, char**)
{
  std::vector<ayw::float2> input_points
  {
    ayw::float2(0.7530204, 1.21816852),
    ayw::float2(1.55495813, 1.02507209),
    ayw::float2(2.44504187, 1.02507209),
    ayw::float2(3.2469796, 1.21816852),
    ayw::float2(3.80193774, 1.56611626),
    ayw::float2(4.0, 2.0),
    ayw::float2(3.80193774, 2.43388374),
    ayw::float2(3.2469796, 2.78183148),
    ayw::float2(2.44504187, 2.97492791),
    ayw::float2(1.55495813, 2.97492791),
    ayw::float2(0.7530204, 2.78183148),
    ayw::float2(0.19806226, 2.43388374),
    ayw::float2(0.0, 2.0),
    ayw::float2(0.19806226, 1.56611626)
  };

  ayw::convex convex_hull;
  convex_hull.build(input_points.begin(), input_points.end());
  convex_hull.simplify(4);

  for (const auto& v : convex_hull.vertices) 
  {
    std::cout << "(" << v.x << "," << v.y << ") ";
  }
  std::cout << std::endl;

  return 0;
}
```
Before the fix the output is: (2,0.917912) (4,1.39949) (4,2.60051) (-9.34015e+07,2.24899e+07).
After the fix the output is: (0.445042,1.02507) (4.44504,1.02507) (3.3569,3.40881) (-0.24698,2.54104).

The following image illustrates the difference between the two versions. The blue polygon is the input n-gon, while the red polygon is the output 4-gon.

<img width="1920" height="967" alt="compare_fix_intersection_ngon_4gon" src="https://github.com/user-attachments/assets/3a85f06e-b12d-4dcc-b7c9-b90fcf9794f9" />
